### PR TITLE
ci: fix immutable-safe release expressions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -216,10 +216,10 @@ jobs:
 
       - name: Create GitHub Release draft (immutable-safe)
         env:
-          GITHUB_TOKEN: ${ secrets.GITHUB_TOKEN }
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          TAG="${ steps.pkg.outputs.tag }"
+          TAG="${{ steps.pkg.outputs.tag }}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             IS_DRAFT="$(gh release view "$TAG" --json isDraft --jq '.isDraft')"
             if [ "$IS_DRAFT" != "true" ]; then
@@ -249,10 +249,10 @@ jobs:
 
       - name: Publish GitHub Release
         env:
-          GITHUB_TOKEN: ${ secrets.GITHUB_TOKEN }
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          TAG="${ steps.pkg.outputs.tag }"
+          TAG="${{ steps.pkg.outputs.tag }}"
           if ! gh release view "$TAG" >/dev/null 2>&1; then
             echo "Expected draft release $TAG to exist before publication."
             exit 1


### PR DESCRIPTION
## Summary
- repair GitHub Actions expressions in the immutable-safe release steps
- preserve draft-first release publication for immutable releases

## Why
The first rollout templated `${{ ... }}` expressions incorrectly into `${ ... }`, which breaks shell evaluation before the release step can run.
