### PR TITLE
[codex] Preserve local work from feature-f264-ai-governance-moderation

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -136,6 +136,41 @@ describe("@plasius/ai-governance", () => {
     });
   });
 
+  it("defaults missing confidence and audit-only outcomes safely", () => {
+    expect(
+      resolveAiGovernanceDecision({
+        requestedDecision: "audit-only",
+        policyId: "policy-audit-only",
+        policyVersion: "2026-05-A",
+        correlationId: "corr-audit-only",
+        reasonCodes: [" ", "pre-reviewed"],
+        featureFlags: {
+          [AI_GOVERNANCE_FEATURE_FLAGS.decisions]: true,
+        },
+      })
+    ).toMatchObject({
+      confidence: 0,
+      outcome: "audit-only",
+      reasonCodes: ["pre-reviewed"],
+    });
+
+    expect(
+      resolveAiGovernanceDecision({
+        requestedDecision: "audit-only",
+        policyId: "policy-audit-default",
+        policyVersion: "2026-05-A",
+        correlationId: "corr-audit-default",
+        confidence: 0.99,
+        featureFlags: {
+          [AI_GOVERNANCE_FEATURE_FLAGS.decisions]: true,
+        },
+      })
+    ).toMatchObject({
+      outcome: "audit-only",
+      reasonCodes: ["governance-defaulted-to-audit"],
+    });
+  });
+
   it("falls back to audit-only when governance flag is disabled", () => {
     expect(
       resolveAiGovernanceDecision({


### PR DESCRIPTION
Preserves local workspace changes found during the worktree/branch orphan sweep.

Source worktree: `/Users/philliphounslow/plasius/.codex-pr-remediation/ai-governance-pr8`
Original branch: `feature/f264-ai-governance-moderation`
Preservation branch: `codex/preserve-ai-governance-feature-f264-ai-governance-moderation-20260518`

Files staged in this preservation commit:
- `tests/index.test.ts`

Validation: not run in this sweep; this PR is draft and intended to prevent local work from being orphaned.
Generated/cache artifacts were intentionally left unstaged.