### PR TITLE
chore: prepare release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 - **Added**
+  - (placeholder)
+
+- **Changed**
+  - (placeholder)
+
+- **Fixed**
+  - (placeholder)
+
+- **Security**
+  - (placeholder)
+
+## [0.1.3] - 2026-05-20
+
+- **Added**
   - Added policy outcome constants and decision-resolution contracts for governance allow/deny/escalate/redact/audit-only flows.
 
 - **Changed**
@@ -41,3 +55,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 [0.1.1]: https://github.com/Plasius-LTD/ai-governance/releases/tag/v0.1.1
 [0.1.2]: https://github.com/Plasius-LTD/ai-governance/releases/tag/v0.1.2
+[0.1.3]: https://github.com/Plasius-LTD/ai-governance/releases/tag/v0.1.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/ai-governance",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/ai-governance",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/ai-governance",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "AI guardrail, policy decision, confidence, and audit contracts for Plasius agentic AI.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- prepare `v0.1.3` for publication from protected `main`
- move the current `Unreleased` notes into `0.1.3`
- stage the follow-up publish run of `.github/workflows/cd.yml` with `bump=none`

## Next step
1. Merge this PR to `main`.
2. Run `.github/workflows/cd.yml` on `main` with `bump=none` to tag, draft the GitHub release, and publish to npm.