### PR TITLE
chore: prepare release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Security**
   - (placeholder)
 
+## [0.1.4] - 2026-06-22
+
+- **Added**
+  - (placeholder)
+
+- **Changed**
+  - (placeholder)
+
+- **Fixed**
+  - (placeholder)
+
+- **Security**
+  - (placeholder)
+
 ## [0.1.3] - 2026-05-20
 
 - **Added**
@@ -56,3 +70,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 [0.1.1]: https://github.com/Plasius-LTD/ai-governance/releases/tag/v0.1.1
 [0.1.2]: https://github.com/Plasius-LTD/ai-governance/releases/tag/v0.1.2
 [0.1.3]: https://github.com/Plasius-LTD/ai-governance/releases/tag/v0.1.3
+[0.1.4]: https://github.com/Plasius-LTD/ai-governance/releases/tag/v0.1.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/ai-governance",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/ai-governance",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/ai-governance",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "AI guardrail, policy decision, confidence, and audit contracts for Plasius agentic AI.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- prepare `v0.1.4` for publication from protected `main`
- update package metadata to `0.1.4`
- move the current `Unreleased` notes into `0.1.4`

The CD workflow will continue only after this release metadata is present on `main`.