### PR TITLE
docs: align AGENTS guidance to Node 24

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ The following repo- or directory-specific guidance from the previous local `AGEN
 This repo is `@plasius/schema`, a TypeScript schema definition and validation library.
 
 ### Setup
-- Use Node.js 22 (see `.nvmrc`) and npm.
+- Use Node.js 24 (see `.nvmrc`) and npm.
 - Install dependencies with `npm ci`.
 
 ### Common commands


### PR DESCRIPTION
## Summary
- update repository-local `AGENTS.md` guidance to match the existing Node.js 24 `.nvmrc` and `package.json` engine declarations

## Validation
- verified `.nvmrc` remains `24` and `package.json` `engines.node` remains `>=24`
