### PR TITLE
fix: fail closed for low-confidence redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - (placeholder)
 
 - **Security**
-  - (placeholder)
+  - Fail closed to `escalate` when an enabled direct redaction decision has confidence below `0.35`, preventing unreliable redaction evidence from becoming an allowed, non-enforcing `audit-only` outcome.
+  - Documented the compatibility distinction between explicit or rollout-disabled `audit-only` decisions and enforced redaction outcomes without changing public signatures or the existing outcome-allowance helper.
 
 ## [0.1.6] - 2026-06-27
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,28 @@ This package defines policy decision contracts for allow, deny, escalate, redact
 - feature-flag snapshots can force audit-only rollout behavior
 - each outcome includes structured audit metadata for downstream compliance and replay
 
+## Outcome semantics
+
+| Outcome | Processing may continue | Enforced control |
+| --- | --- | --- |
+| `allow` | Yes | No additional control |
+| `deny` | No | Request is blocked |
+| `escalate` | No | Human or higher-assurance review is required |
+| `redact` | Yes | Redaction must be applied by the caller |
+| `audit-only` | Yes | None; evidence is recorded without enforcing a control |
+
+When governance is enabled, a direct `redact` decision with normalized confidence below `0.35` resolves to `escalate` with reason code `low-confidence-redaction-escalated`. This is fail-closed: unreliable evidence cannot silently turn a privacy control into a non-enforcing pass. The audit outcome mirrors the resolved `escalate` outcome.
+
+`audit-only` remains an allowed, deliberately non-enforcing public outcome for compatibility. It can be requested explicitly, and it is also returned with source `feature-disabled` while the governance feature flag is absent or false. Callers that require an enforced privacy control must inspect the concrete outcome and must not treat `isAiGovernanceOutcomeAllowed(...)` as proof that redaction occurred.
+
+### Rollout and rollback
+
+Set `ai.governance.enabled` to `true` to enforce confidence policy. Setting it to `false`, or omitting it, is the rollout rollback path and resolves every request to feature-disabled `audit-only`; this permits processing without applying redaction. Use that rollback only when the deployment's surrounding controls make non-enforcement acceptable.
+
+### Migration note
+
+This security correction does not change public types or function signatures. Consumers that previously expected enabled low-confidence direct redaction to return `audit-only` must handle `escalate` as a non-allowing review state. Consumers using `isAiGovernanceOutcomeAllowed` retain existing behavior for all five outcomes.
+
 ## Install
 
 ```bash

--- a/docs/adrs/adr-0002-fail-closed-redaction-and-audit-only-semantics.md
+++ b/docs/adrs/adr-0002-fail-closed-redaction-and-audit-only-semantics.md
@@ -1,0 +1,26 @@
+# ADR-0002: Fail-closed redaction and audit-only semantics
+
+- Date: 2026-07-13
+- Status: Accepted
+
+## Context
+
+The governance resolver previously converted an enabled, low-confidence direct `redact` request into `audit-only`. The public allowance helper intentionally treats `audit-only` as permitting processing, so a requested privacy control could be lost precisely when its confidence evidence was unreliable.
+
+The package also uses feature-disabled `audit-only` as its established rollout and rollback behavior. Changing that public behavior, or globally making `audit-only` non-allowing, would break existing consumers and conflate rollout state with an enforced policy decision.
+
+## Decision
+
+When `ai.governance.enabled` is true, a direct `redact` request whose normalized confidence is below `0.35` resolves to `escalate`. The resolver appends the stable reason code `low-confidence-redaction-escalated`, records `escalate` in audit metadata, and therefore produces a result that `isAiGovernanceOutcomeAllowed` rejects.
+
+The threshold is inclusive on the valid side: confidence `0.35` retains `redact`. Non-finite and negative confidence normalize to zero and therefore escalate. Existing caller reason codes remain ordered ahead of the policy reason and caller input is not mutated.
+
+Feature-disabled decisions continue to resolve to `audit-only` with source `feature-disabled`, and an explicitly requested `audit-only` decision remains allowed and non-enforcing. The public outcome union, resolver signature, result shape, and allowance-helper behavior are unchanged.
+
+## Consequences
+
+- Unreliable direct redaction evidence fails closed to a review state instead of becoming a non-enforcing pass.
+- Consumers must handle `escalate` for enabled low-confidence direct redaction after upgrading.
+- `isAiGovernanceOutcomeAllowed` answers whether processing may continue; it does not prove that a privacy control was applied.
+- Disabling the feature remains a compatible rollback mechanism, but surrounding systems must accept that no governance control is enforced in that state.
+- Boundary, invalid-confidence, reason-ordering, audit, feature-disabled, and exhaustive allowance tests protect these semantics.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -1,3 +1,4 @@
 # Architecture Decision Records
 
 - [ADR-0001: @plasius/ai-governance Package Boundary](./adr-0001-package-boundary.md)
+- [ADR-0002: Fail-closed redaction and audit-only semantics](./adr-0002-fail-closed-redaction-and-audit-only-semantics.md)

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export type AiGovernanceDataClassification =
 const AI_GOVERNANCE_CONFIDENCE_THRESHOLDS = {
   redactForSensitiveAllow: 0.4,
   escalateOnLowConfidenceDeny: 0.45,
-  keepRedactionOnLowConfidenceRedact: 0.35,
+  escalateOnLowConfidenceRedact: 0.35,
 } as const;
 
 function clampRatio(value: number): number {
@@ -172,10 +172,10 @@ export function resolveAiGovernanceDecision(
 
   if (
     input.requestedDecision === "redact" &&
-    normalizedConfidence < AI_GOVERNANCE_CONFIDENCE_THRESHOLDS.keepRedactionOnLowConfidenceRedact
+    normalizedConfidence < AI_GOVERNANCE_CONFIDENCE_THRESHOLDS.escalateOnLowConfidenceRedact
   ) {
-    outcome = "audit-only";
-    reasonCodes.push("redaction-disabled-for-unreliable-input");
+    outcome = "escalate";
+    reasonCodes.push("low-confidence-redaction-escalated");
   }
 
   if (reasonCodes.length === 0) {
@@ -207,6 +207,13 @@ export function resolveAiGovernanceDecision(
   };
 }
 
+/**
+ * Return whether processing may continue for an outcome.
+ *
+ * `audit-only` is deliberately non-enforcing: it permits processing without
+ * applying redaction or another policy control. Callers that require an
+ * enforced privacy control must inspect the concrete outcome as well.
+ */
 export function isAiGovernanceOutcomeAllowed(
   outcome: AiGovernanceOutcome
 ): outcome is "allow" | "redact" | "audit-only" {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -79,43 +79,112 @@ describe("@plasius/ai-governance", () => {
     });
   });
 
-  it("defaults non-finite confidence to zero before policy evaluation", () => {
-    expect(
-      resolveAiGovernanceDecision({
-        requestedDecision: "allow",
-        policyId: "policy-nan",
-        policyVersion: "2026-05-A",
-        correlationId: "corr-nan",
-        dataClassification: "sensitive",
-        confidence: Number.NaN,
-        featureFlags: {
-          [AI_GOVERNANCE_FEATURE_FLAGS.decisions]: true,
+  it.each([
+    ["NaN", Number.NaN],
+    ["positive infinity", Number.POSITIVE_INFINITY],
+    ["negative infinity", Number.NEGATIVE_INFINITY],
+    ["negative confidence", -0.01],
+  ])(
+    "normalizes %s to zero and fails direct redaction closed",
+    (_label, confidence) => {
+      expect(
+        resolveAiGovernanceDecision({
+          requestedDecision: "redact",
+          policyId: "policy-invalid-confidence",
+          policyVersion: "2026-05-A",
+          correlationId: "corr-invalid-confidence",
+          confidence,
+          featureFlags: {
+            [AI_GOVERNANCE_FEATURE_FLAGS.decisions]: true,
+          },
+        })
+      ).toMatchObject({
+        confidence: 0,
+        outcome: "escalate",
+        reasonCodes: ["low-confidence-redaction-escalated"],
+        audit: {
+          outcome: "escalate",
+          confidence: 0,
         },
-      })
-    ).toMatchObject({
-      confidence: 0,
-      outcome: "redact",
-      reasonCodes: ["low-confidence-sensitive-content"],
+      });
+    }
+  );
+
+  it("fails closed when direct redaction confidence is unreliable", () => {
+    const result = resolveAiGovernanceDecision({
+      requestedDecision: "redact",
+      policyId: "policy-redact",
+      policyVersion: "2026-05-A",
+      correlationId: "corr-redact",
+      confidence: 0.1,
+      featureFlags: {
+        [AI_GOVERNANCE_FEATURE_FLAGS.decisions]: true,
+      },
     });
+
+    expect(result).toMatchObject({
+      requestedDecision: "redact",
+      outcome: "escalate",
+      reasonCodes: ["low-confidence-redaction-escalated"],
+      source: "policy",
+      audit: {
+        outcome: "escalate",
+      },
+    });
+    expect(isAiGovernanceOutcomeAllowed(result.outcome)).toBe(false);
   });
 
-  it("disables low-confidence redaction requests for audit only", () => {
-    expect(
-      resolveAiGovernanceDecision({
+  it.each([
+    [0.349999, "escalate", "low-confidence-redaction-escalated"],
+    [0.35, "redact", "governance-policy-pass"],
+    [1, "redact", "governance-policy-pass"],
+  ] as const)(
+    "applies the direct redaction threshold at confidence %s",
+    (confidence, outcome, reasonCode) => {
+      const result = resolveAiGovernanceDecision({
         requestedDecision: "redact",
-        policyId: "policy-redact",
+        policyId: "policy-redact-boundary",
         policyVersion: "2026-05-A",
-        correlationId: "corr-redact",
-        confidence: 0.1,
+        correlationId: `corr-redact-${confidence}`,
+        confidence,
         featureFlags: {
           [AI_GOVERNANCE_FEATURE_FLAGS.decisions]: true,
         },
-      })
-    ).toMatchObject({
+      });
+
+      expect(result).toMatchObject({
+        confidence,
+        outcome,
+        reasonCodes: [reasonCode],
+        audit: { outcome },
+      });
+      expect(isAiGovernanceOutcomeAllowed(result.outcome)).toBe(
+        outcome === "redact"
+      );
+    }
+  );
+
+  it("appends the fail-closed reason without mutating caller reasons", () => {
+    const callerReasons = Object.freeze(["caller-review-required", " "]);
+
+    const result = resolveAiGovernanceDecision({
       requestedDecision: "redact",
-      outcome: "audit-only",
-      reasonCodes: ["redaction-disabled-for-unreliable-input"],
+      policyId: "policy-redact-reasons",
+      policyVersion: "2026-05-A",
+      correlationId: "corr-redact-reasons",
+      confidence: 0.2,
+      reasonCodes: callerReasons,
+      featureFlags: {
+        [AI_GOVERNANCE_FEATURE_FLAGS.decisions]: true,
+      },
     });
+
+    expect(result.reasonCodes).toEqual([
+      "caller-review-required",
+      "low-confidence-redaction-escalated",
+    ]);
+    expect(result.reasonCodes).not.toBe(callerReasons);
+    expect(callerReasons).toEqual(["caller-review-required", " "]);
   });
 
   it("adds a pass reason when governance allows the requested outcome", () => {
@@ -171,26 +240,47 @@ describe("@plasius/ai-governance", () => {
     });
   });
 
-  it("falls back to audit-only when governance flag is disabled", () => {
-    expect(
-      resolveAiGovernanceDecision({
-        requestedDecision: "allow",
-        policyId: "policy-audit",
+  it.each([
+    ["absent", undefined],
+    ["false", false],
+  ] as const)(
+    "keeps rollout-disabled low-confidence redaction audit-only when the flag is %s",
+    (_label, enabled) => {
+      const featureFlags =
+        enabled === undefined
+          ? undefined
+          : { [AI_GOVERNANCE_FEATURE_FLAGS.decisions]: enabled };
+      const result = resolveAiGovernanceDecision({
+        requestedDecision: "redact",
+        policyId: "policy-rollout-disabled",
         policyVersion: "2026-05-A",
-        correlationId: "corr-3",
-        confidence: 0.99,
-      })
-    ).toMatchObject({
-      requestedDecision: "allow",
-      outcome: "audit-only",
-      reasonCodes: ["governance-feature-disabled"],
-      source: "feature-disabled",
-      enabledFeatureFlags: [],
-    });
-  });
+        correlationId: "corr-rollout-disabled",
+        confidence: 0.1,
+        featureFlags,
+      });
 
-  it("identifies audit-only as a non-enforcing outcome", () => {
-    expect(isAiGovernanceOutcomeAllowed("audit-only")).toBe(true);
-    expect(isAiGovernanceOutcomeAllowed("deny")).toBe(false);
-  });
+      expect(result).toMatchObject({
+        requestedDecision: "redact",
+        outcome: "audit-only",
+        reasonCodes: ["governance-feature-disabled"],
+        source: "feature-disabled",
+        enabledFeatureFlags: [],
+        audit: { outcome: "audit-only" },
+      });
+      expect(isAiGovernanceOutcomeAllowed(result.outcome)).toBe(true);
+    }
+  );
+
+  it.each([
+    ["allow", true],
+    ["deny", false],
+    ["escalate", false],
+    ["redact", true],
+    ["audit-only", true],
+  ] as const)(
+    "reports whether the %s outcome allows processing",
+    (outcome, allowed) => {
+      expect(isAiGovernanceOutcomeAllowed(outcome)).toBe(allowed);
+    }
+  );
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -23,8 +23,8 @@ export default defineConfig({
       thresholds: {
         lines: 80,
         functions: 80,
-        statements: 75,
-        branches: 60,
+        statements: 80,
+        branches: 80,
       },
     },
   },


### PR DESCRIPTION
## Summary
- escalate enabled low-confidence redaction decisions instead of allowing audit-only outcomes
- preserve explicit and feature-disabled audit-only compatibility
- document the security boundary, rollback behavior, and migration semantics
- strengthen boundary, invalid-input, audit-parity, and outcome helper coverage

## Security validation
The original issue reproduced on the pre-patch revision: an enabled redaction decision at confidence 0.1 returned an allowed audit-only outcome. It no longer reproduces after this change: confidence below 0.35 returns a non-allowing escalate outcome, while 0.35 and above retains redact. Explicit audit-only requests and feature-disabled redaction remain allowed and non-enforcing as designed.

## Validation
- 23/23 tests passed under Node 24
- 100% statements, branches, functions, and lines
- typecheck passed
- ESLint passed
- build passed
- audit:all passed
- package check passed
- changed source appears in LCOV
- independent correctness review found no issues

Closes #35