### PR TITLE
ci: refine Codecov and runner policy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,7 +40,7 @@ jobs:
 
   publish:
     needs: prepare_release
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CD_RUNNER_LABELS || '["self-hosted","Linux","X64"]') }}
     environment: production
     steps:
       - name: Checkout prepared release commit
@@ -107,6 +107,38 @@ jobs:
             npm test
           fi
           if has_script pack:check; then npm run pack:check; fi
+
+      - name: Locate coverage report for Codecov
+        id: codecov_coverage
+        if: steps.release.outputs.should_finalize_release == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          LCOV_FILE="$(find coverage -type f -name lcov.info | head -n 1 || true)"
+          if [ -z "${LCOV_FILE}" ] || [ ! -f "${LCOV_FILE}" ]; then
+            echo "No lcov.info found; skipping Codecov upload."
+            echo "available=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "Using coverage report: ${LCOV_FILE}"
+          echo "available=true" >> "${GITHUB_OUTPUT}"
+          echo "files=${LCOV_FILE}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload coverage to Codecov (best effort)
+        id: codecov
+        if: steps.release.outputs.should_finalize_release == 'true' && steps.codecov_coverage.outputs.available == 'true'
+        continue-on-error: true
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ steps.codecov_coverage.outputs.files }}
+          flags: unittests
+          fail_ci_if_error: false
+          slug: ${{ github.repository }}
+
+      - name: Report Codecov upload warning
+        if: always() && steps.codecov.outcome == 'failure'
+        run: echo "::warning title=Codecov upload unavailable::Release coverage upload failed or was quota-limited; release validation and publication will continue."
 
       - name: Generate SBOM (CycloneDX)
         if: steps.release.outputs.should_finalize_release == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,13 @@ jobs:
             const fallbackRunner = process.env.FALLBACK_RUNNER_LABEL
             let selectedRunnerJson = JSON.stringify(fallbackRunner)
 
-            if (context.eventName === "pull_request") {
-              core.info(`Pull request CI always uses ${fallbackRunner}.`)
+            const isForkPullRequest =
+              context.eventName === "pull_request" &&
+              context.payload.pull_request?.head?.repo?.full_name !==
+                `${context.repo.owner}/${context.repo.repo}`
+
+            if (isForkPullRequest) {
+              core.info(`Fork pull request CI uses ${fallbackRunner} to protect the self-hosted runner.`)
               core.setOutput("runner_labels", selectedRunnerJson)
               return
             }
@@ -155,12 +160,3 @@ jobs:
             echo "Coverage gate failed: ${PCT}% < 80%"
             exit 1
           }
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ${{ env.LCOV_FILE }}
-          flags: unittests
-          fail_ci_if_error: true
-          slug: ${{ github.repository }}


### PR DESCRIPTION
Remove Codecov uploads from CI, keep release uploads non-blocking when quota-limited, and prefer self-hosted runners for trusted workflow jobs.