### PR TITLE
ci: bootstrap reusable self-hosted validation (#40)

### DIFF
--- a/.github/workflows/ci-self-hosted.yml
+++ b/.github/workflows/ci-self-hosted.yml
@@ -1,0 +1,90 @@
+name: Self-hosted CI
+
+on:
+  workflow_call:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  build-test:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on:
+      group: Public CI - Quarantined
+      labels: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci --no-fund --no-audit --legacy-peer-deps
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Security audit (runtime deps)
+        run: npm run audit:npm
+
+      - name: Build
+        run: npm run build --if-present
+
+      - name: Public package integrity
+        run: npm run pack:check
+
+      - name: Test with coverage
+        run: |
+          set -euo pipefail
+
+          if node -e "const s=(require('./package.json').scripts||{})['test:coverage']||''; process.exit(s.includes('vitest') ? 0 : 1)"; then
+            npm run test:coverage -- --coverage.reporter=lcov --coverage.reporter=text-summary
+          elif node -e "const s=(require('./package.json').scripts||{})['test:coverage']||''; process.exit(s ? 0 : 1)"; then
+            npm run test:coverage
+          elif node -e "const s=(require('./package.json').scripts||{}).test||''; process.exit(s.includes('vitest') ? 0 : 1)"; then
+            npm run test -- --coverage --coverage.reporter=lcov --coverage.reporter=text-summary
+          else
+            npm run test -- --coverage
+          fi
+
+      - name: Locate coverage report
+        run: |
+          set -euo pipefail
+          LCOV_FILE="$(find coverage -type f -name lcov.info | head -n 1 || true)"
+          if [ -z "$LCOV_FILE" ]; then
+            echo "No lcov.info found under coverage/."
+            exit 1
+          fi
+          echo "Using coverage report: $LCOV_FILE"
+          echo "LCOV_FILE=$LCOV_FILE" >> "$GITHUB_ENV"
+
+      - name: Enforce line coverage >= 80%
+        run: |
+          set -euo pipefail
+          if [ -z "${LCOV_FILE:-}" ] || [ ! -f "$LCOV_FILE" ]; then
+            echo "Missing coverage report: ${LCOV_FILE:-unset}"
+            exit 1
+          fi
+
+          read -r LF LH <<EOF
+          $(awk -F: '/^LF:/{lf+=$2} /^LH:/{lh+=$2} END{printf "%d %d\n", lf+0, lh+0}' "$LCOV_FILE")
+          EOF
+
+          if [ "$LF" -le 0 ]; then
+            echo "Invalid coverage totals (LF=$LF, LH=$LH)"
+            exit 1
+          fi
+
+          PCT=$(awk -v lh="$LH" -v lf="$LF" 'BEGIN{printf "%.2f", (lh/lf)*100}')
+          echo "Line coverage: ${PCT}% (${LH}/${LF})"
+
+          awk -v pct="$PCT" 'BEGIN{exit(pct >= 80 ? 0 : 1)}' || {
+            echo "Coverage gate failed: ${PCT}% < 80%"
+            exit 1
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,12 @@ permissions:
   actions: read
   contents: read
 
-env:
-  FALLBACK_RUNNER_LABEL: ubuntu-latest
-  SELF_HOSTED_RUNNER_LABELS: '["self-hosted","Linux","X64"]'
-
 jobs:
   build-test:
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && '"ubuntu-latest"' || vars.CI_RUNNER_LABELS || '["self-hosted","Linux","X64"]') }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on:
+      group: Public CI - Quarantined
+      labels: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v4
 
@@ -39,6 +38,9 @@ jobs:
 
       - name: Build
         run: npm run build --if-present
+
+      - name: Public package integrity
+        run: npm run pack:check
 
       - name: Test with coverage
         run: |


### PR DESCRIPTION
## Summary

- add the repository-owned reusable self-hosted validation workflow required by the restricted runner group
- retain fixed `Public CI - Quarantined` routing, same-repository pull-request guard, package integrity, and the 80% coverage gate
- make no runtime, package API, publication, or feature change

## Bootstrap boundary

This file must exist on `main` before the event-facing caller can reference its allowlisted stable identity. Exact-main CI will run immediately after merge; feature and release PRs remain subject to normal checks.

## Validation

- Node 24 typecheck, lint, production audit, build, tests, coverage, and package checks pass locally
- 23/23 tests; 100% statements, branches, functions, and lines
- workflow YAML parses successfully and matches the validated release-branch copy byte-for-byte

Tracking: #40
